### PR TITLE
🔧 fix: Claude Action の認証設定を CLAUDE_CODE_OAUTH_TOKEN に修正 #17

### DIFF
--- a/.github/workflows/claude-auto-review.yaml
+++ b/.github/workflows/claude-auto-review.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Automatic PR Review
         uses: anthropics/claude-code-action@v1-dev
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -34,7 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1-dev
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Issue

- resolve: https://github.com/takashi605/schema-fiarst-graphql-api/issues/17

## なぜこの変更が必要なのか？

PR #16 で GitHub Actions の `claude-auto-review.yaml` ワークフローが失敗していました。エラーログを確認すると、環境変数 `ANTHROPIC_API_KEY` または `CLAUDE_CODE_OAUTH_TOKEN` が必要であるとのメッセージが表示されていましたが、リポジトリには `CLAUDE_CODE_OAUTH_TOKEN` シークレットのみが設定されていました。

この不整合により、ワークフローが正常に動作しませんでした。

## 変更内容

- `.github/workflows/claude-auto-review.yaml` で `anthropic_api_key` を `claude_code_oauth_token` に変更
- `.github/workflows/claude.yaml` で `anthropic_api_key` を `claude_code_oauth_token` に変更

両方のワークフローファイルで、設定済みの `CLAUDE_CODE_OAUTH_TOKEN` シークレットを正しく参照するように修正しました。

## テスト計画

- [ ] このPRがマージされた後、新しいPRを作成して `claude-auto-review` ワークフローが正常に動作することを確認