### PR TITLE
🌐 feat: サブエージェントの説明を日本語に翻訳 #24

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer
-description: Use this agent to perform comprehensive code review and quality assessment of recently written or modified code. The agent evaluates code quality, security, performance, and error handling while providing specific improvement suggestions. Invoke after completing code implementation, fixing bugs, or refactoring.
+description: 新しく書かれたコードや修正されたコードの包括的なコードレビューと品質評価を行うエージェントです。コード品質、セキュリティ、パフォーマンス、エラーハンドリングを評価し、具体的な改善提案を提供します。コード実装完了後、バグ修正後、リファクタリング後に使用してください。
 model: sonnet
 color: cyan
 ---

--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -1,7 +1,7 @@
 ---
 name: coder
 description: |
-  Use this agent when you need to handle coding tasks including code generation, modification, refactoring, debugging, or test creation. This agent specializes in writing clean, maintainable code following best practices and SOLID principles.
+  コード生成、変更、リファクタリング、デバッグ、テスト作成などのコーディングタスクを扱う際に使用するエージェントです。このエージェントは、ベストプラクティスとSOLID原則に従って、クリーンで保守可能なコードの作成に特化しています。
 
   Examples:
   <example>

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -1,7 +1,7 @@
 ---
 name: tester
 description: |
-  Use this agent when you need to create, execute, or review tests for your codebase. This includes writing unit tests, integration tests, API tests, designing test cases, improving test coverage, or reviewing existing test code for quality and completeness. The agent specializes in test-driven development practices and ensuring code quality through comprehensive testing strategies.
+  コードベースのテスト作成、実行、レビューが必要な際に使用するエージェントです。ユニットテスト、統合テスト、APIテストの作成、テストケースの設計、テストカバレッジの改善、既存テストコードの品質・完全性レビューなどを行います。テスト駆動開発の実践と包括的なテスト戦略を通じたコード品質の確保に特化しています。
 
   Examples:
   <example>


### PR DESCRIPTION
## Issue

- resolve: TASK#24

## なぜこの変更が必要なのか？

日本語でやり取りをしているにも関わらず、エージェントの説明が英語であったため、Claude が適切なタイミングでサブエージェントを選択できていませんでした。

## 変更内容

- `code-reviewer` エージェントの description を日本語に翻訳
- `coder` エージェントの description を日本語に翻訳  
- `tester` エージェントの description を日本語に翻訳

## 期待する効果

日本語でのコミュニケーション時に、適切なタイミングでサブエージェントが自動選択されるようになります。

## pr_agent:summary

## pr_agent:walkthrough